### PR TITLE
Use childNodes instead of children for walkDom

### DIFF
--- a/src/content/inject.ts
+++ b/src/content/inject.ts
@@ -10,10 +10,10 @@ window.onload = (): void => {
   const picker = new ElementPicker((selected: Element) => {
     walkDOM(
       selected,
-      (childNode: Element): Walk => {
-        if (childNode instanceof HTMLElement) {
+      (childNode: Node): Walk => {
+        if (childNode.textContent) {
           chrome.runtime.sendMessage(
-            { request: 'debabbleText', data: childNode.innerText },
+            { request: 'debabbleText', data: childNode.textContent },
             (response: any): void => {} // TODO: we want to return if we successfully decrypted something
           );
         }

--- a/src/content/walkdom.ts
+++ b/src/content/walkdom.ts
@@ -5,12 +5,12 @@ export enum Walk {
   CONTINUE
 }
 
-export const walkDOM = (root: Element, callback: (elem: Element) => Walk) => {
+export const walkDOM = (root: Node, callback: (elem: Node) => Walk) => {
   if (callback(root) == Walk.STOP) {
     return;
   }
-  for (var i = 0; i < root.children.length; i++) {
-    const child: Element = root.children[i];
+  for (var i = 0; i < root.childNodes.length; i++) {
+    const child: Node = root.childNodes[i];
     walkDOM(child, callback);
   }
 };


### PR DESCRIPTION
This lets us recurse into non-element Nodes, such as header or paragraph
elements. This also fixes decryption in discord compact mode since
message content is inside of a header.