### PR TITLE
popup: Remove decrypt box and add copy icon

### DIFF
--- a/public/html/popup.html
+++ b/public/html/popup.html
@@ -19,15 +19,18 @@
         <div id="keystore-icon">
           <i class="fa fa-key fa-1x fa-babble-selector"></i>
         </div>
+        <div id="copy-icon">
+          <i class="fa fa-copy fa-1x fa-babble-selector"></i>
+        </div>
       </div>
     </div>
     </div>
     <div class="container-col">
       <div class="item">
-        <textarea class="form-control babble-text" id="plaintext" placeholder="Plain Text" rows=5></textarea>
+        <textarea class="form-control babble-text" id="plaintext" placeholder="Plain Text" rows="5"></textarea>
       </div>
       <div class="item">
-        <textarea readonly class="form-control babble-text" id="decrypted-text" placeholder="Decrypted Text" rows=5></textarea>
+        <textarea readonly class="form-control babble-text" id="display-text" rows="5"></textarea>
       </div>
     </div>
     <br>


### PR DESCRIPTION
* Decrypt box is now a display box
* Encrypted text is output to the display box (good for sites that we
don't support input box for)
* Add copy icon for copying the text inside of the display box