### PR TITLE
Add keybindings for popup and decryption picker

### DIFF
--- a/platform/chromium/manifest.json
+++ b/platform/chromium/manifest.json
@@ -42,6 +42,19 @@
     "dist/html/decrypt.html",
     "dist/js/web_accessible_resources/decrypt.js"
   ],
+  "commands": {
+    "_execute_browser_action": {
+      "suggested_key": {
+        "default": "Alt+Shift+Z"
+      }
+    },
+    "toggle-decryption": {
+      "suggested_key": {
+        "default": "Alt+Shift+D"
+      },
+      "description": "Enter decryption picker mode"
+    }
+  },
   "permissions": [
     "debugger",
     "storage",

--- a/platform/firefox/manifest.json
+++ b/platform/firefox/manifest.json
@@ -44,6 +44,19 @@
     "dist/html/decrypt.html",
     "dist/js/web_accessible_resources/decrypt.js"
   ],
+  "commands": {
+    "_execute_browser_action": {
+      "suggested_key": {
+        "default": "Alt+Shift+Z"
+      }
+    },
+    "toggle-decryption": {
+      "suggested_key": {
+        "default": "Alt+Shift+D"
+      },
+      "description": "Enter decryption picker mode"
+    }
+  },
   "permissions": [
     "storage",
     "tabs",

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -55,3 +55,12 @@ chrome.runtime.onMessage.addListener(
     }
   }
 );
+
+chrome.commands.onCommand.addListener(async (command: string) => {
+  if (command === 'toggle-decryption') {
+    await sendMessageActiveTab({
+      request: 'toggleElementPicker',
+      requestClass: 'decryptionPicker'
+    });
+  }
+});

--- a/src/content/element-picker.ts
+++ b/src/content/element-picker.ts
@@ -28,6 +28,7 @@ export class ElementPicker {
   private lastElem: HTMLElement | null;
   private lastBackgroundColor: string | null;
   private lastBorder: string | null;
+  private _isActive: boolean;
   constructor(
     callbackHover: (elem: Element) => void,
     callbackClick: (elem: EventTarget) => void,
@@ -40,6 +41,7 @@ export class ElementPicker {
     this.callbackHover = callbackHover;
     this.callbackClick = callbackClick;
     this.callbackOnDeactivate = callbackOnDeactivate;
+    this._isActive = false;
     this.lastElem = null;
     this.lastBackgroundColor = null;
     this.lastBorder = null;
@@ -83,11 +85,16 @@ export class ElementPicker {
     }
   };
 
+  isActive = (): boolean => {
+    return this._isActive;
+  };
+
   activate = (): void => {
     document.addEventListener('click', this.onMouseClickEvent, true);
     document.addEventListener('keydown', this.onKeydownEvent, true);
     document.addEventListener('mousemove', this.onMouseMoveEvent, false);
     document.body.style.cursor = 'crosshair';
+    this._isActive = true;
   };
 
   deactivate = (triggerCallback: boolean = true): void => {
@@ -101,5 +108,6 @@ export class ElementPicker {
     if (triggerCallback) {
       this.callbackOnDeactivate();
     }
+    this._isActive = false;
   };
 }

--- a/src/content/inject.ts
+++ b/src/content/inject.ts
@@ -28,6 +28,40 @@ import { load } from './loader';
 window.onload = (): void => {
   var cryptFrame: HTMLIFrameElement | null;
 
+  const activatePicker = (): void => {
+    deletePickerIFrame();
+    cryptFrame = document.createElement('iframe');
+    cryptFrame.src = chrome.runtime.getURL('dist/html/decrypt.html');
+    const pickerCSSStyle: string = [
+      'background: transparent',
+      'border: 0',
+      'border-radius: 0',
+      'box-shadow: none',
+      'display: block',
+      'height: 100%',
+      'left: 0',
+      'margin: 0',
+      'max-height: none',
+      'max-width: none',
+      'opacity: 1',
+      'outline: 0',
+      'padding: 0',
+      'position: fixed',
+      'top: 0',
+      'visibility: visible',
+      'width: 100%',
+      'pointer-events: none', // this lets us be the top layer and still highlight DOM nodes
+      'z-index: 2147483647',
+      ''
+    ].join(' !important;');
+    cryptFrame.style.cssText = pickerCSSStyle;
+    // We don't append to the body because we are setting the frame's
+    // width and height to be 100%. Prevents the picker from only being
+    // able to hover the iframe.
+    document.documentElement.appendChild(cryptFrame);
+    picker.activate();
+  };
+
   const deletePickerIFrame = (): void => {
     if (picker) {
       picker.deactivate();
@@ -116,37 +150,11 @@ window.onload = (): void => {
         case 'decryptionPicker':
           switch (request.request) {
             case 'activateElementPicker':
-              deletePickerIFrame();
-              cryptFrame = document.createElement('iframe');
-              cryptFrame.src = chrome.runtime.getURL('dist/html/decrypt.html');
-              const pickerCSSStyle: string = [
-                'background: transparent',
-                'border: 0',
-                'border-radius: 0',
-                'box-shadow: none',
-                'display: block',
-                'height: 100%',
-                'left: 0',
-                'margin: 0',
-                'max-height: none',
-                'max-width: none',
-                'opacity: 1',
-                'outline: 0',
-                'padding: 0',
-                'position: fixed',
-                'top: 0',
-                'visibility: visible',
-                'width: 100%',
-                'pointer-events: none', // this lets us be the top layer and still highlight DOM nodes
-                'z-index: 2147483647',
-                ''
-              ].join(' !important;');
-              cryptFrame.style.cssText = pickerCSSStyle;
-              // We don't append to the body because we are setting the frame's
-              // width and height to be 100%. Prevents the picker from only being
-              // able to hover the iframe.
-              document.documentElement.appendChild(cryptFrame);
-              picker.activate();
+              activatePicker();
+              sendResponse({ success: true });
+              break;
+            case 'toggleElementPicker':
+              picker.isActive() ? deletePickerIFrame() : activatePicker();
               sendResponse({ success: true });
               break;
             case 'deletePickerIFrame':


### PR DESCRIPTION
* Activate decryption element picker : Alt+Shift+D
* Activate popup: Alt+Shift+Z

### Submitter Checklist

- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Tested on Firefox (`npm run firefox`)
- [x] Tested on Chromium (`npm run chromium`)
