### PR TITLE
popup: Focus the textarea when the popup opens

### DIFF
--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -26,6 +26,7 @@ window.addEventListener( 'DOMContentLoaded', ( event: Event ) => {
   const plaintext: HTMLTextAreaElement | null = document.getElementById(
     'plaintext'
   ) as HTMLTextAreaElement;
+  plaintext.focus();
 
   const displaytext: HTMLTextAreaElement | null = document.getElementById(
     'display-text'


### PR DESCRIPTION
This works in tandem with the keybindings. When a user opens the popup,
let them start writing without needing to move their mouse to manually
focus the textarea.

### Submitter Checklist

- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Tested on Firefox (`npm run firefox`)
- [x] Tested on Chromium (`npm run chromium`)
