### PR TITLE
website: Add Weibo support

### DIFF
--- a/platform/chromium/manifest.json
+++ b/platform/chromium/manifest.json
@@ -27,6 +27,7 @@
         "dist/js/content/website.js",
         "dist/js/content/websites/discord.js",
         "dist/js/content/websites/slack.js",
+        "dist/js/content/websites/weibo.js",
         "dist/js/utils/message.js",
         "dist/js/utils/webutils.js",
         "dist/js/vendor.js"

--- a/platform/firefox/manifest.json
+++ b/platform/firefox/manifest.json
@@ -26,6 +26,7 @@
         "dist/js/content/website.js",
         "dist/js/content/websites/discord.js",
         "dist/js/content/websites/slack.js",
+        "dist/js/content/websites/weibo.js",
         "dist/js/utils/message.js",
         "dist/js/utils/webutils.js",
         "dist/js/vendor.js"

--- a/src/content/loader.ts
+++ b/src/content/loader.ts
@@ -20,14 +20,16 @@
 'use strict';
 
 import { Website } from './website';
-import { Slack } from './websites/slack';
 import { Discord } from './websites/discord';
+import { Slack } from './websites/slack';
+import { Weibo } from './websites/weibo';
 
 export const load = ( location: Location ): Website | null => {
   let siteClasses: Website[] = [];
 
-  siteClasses.push( new Slack() );
   siteClasses.push( new Discord() );
+  siteClasses.push( new Slack() );
+  siteClasses.push( new Weibo() );
 
   for ( const siteClass of siteClasses ) {
     if ( window.location.hostname === siteClass.getDomain() ) {

--- a/src/content/websites/weibo.ts
+++ b/src/content/websites/weibo.ts
@@ -1,0 +1,67 @@
+/*
+ * This file is part of the Babble project.
+ * Babble is a platform agnostic browser extension that allows for easy
+ * encryption and decryption of text data across the web.
+ * Copyright (C) 2019  keur, yvbbrjdr
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+'use strict';
+
+import { Website } from '../website';
+import { documentObserver } from '../../utils/webutils';
+
+export class Weibo extends Website {
+  private targetElement: HTMLTextAreaElement | null;
+  constructor () {
+    super();
+    this.domain = 'www.weibo.com';
+    this.targetElement = null;
+  }
+
+  register (): void {
+    documentObserver( ( mutationsList: MutationRecord[], observer: MutationObserver ) => {
+      this.targetElement = document.querySelector( 'textarea.W_input' );
+    } );
+  }
+
+  tunnelInput ( s: string ): boolean {
+    if ( !this.targetElement ) {
+      return false;
+    }
+    this.targetElement.value = s;
+    this.targetElement.dispatchEvent( new KeyboardEvent( 'keyup', { bubbles: true } ) );
+    return true;
+  }
+
+  submitInput (): boolean {
+    if ( !this.targetElement ) {
+      return false;
+    }
+    const submit = document.querySelector( '[node-type=submit]' ) as HTMLAnchorElement;
+    if ( submit.classList.contains( 'W_btn_a_disable' ) ) {
+      return false;
+    }
+    submit.click();
+    return true;
+  }
+
+  clearInput (): boolean {
+    if ( !this.targetElement ) {
+      return false;
+    }
+    this.targetElement.value = '';
+    return true;
+  }
+}

--- a/supported-websites.md
+++ b/supported-websites.md
@@ -2,6 +2,7 @@
 
 - Discord
 - Slack
+- Weibo
 
 For unsupported websites, you can copy the encrypted text from the popup to the
 textbox in the website. Also, pull requests about new website support are

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -13,6 +13,7 @@ module.exports = {
         'content/website': path.join(__dirname, srcDir + 'content/website.ts'),
         'content/websites/discord': path.join(__dirname, srcDir + 'content/websites/discord.ts'),
         'content/websites/slack': path.join(__dirname, srcDir + 'content/websites/slack.ts'),
+        'content/websites/weibo': path.join(__dirname, srcDir + 'content/websites/weibo.ts'),
         'options/options': path.join(__dirname, srcDir + 'options/options.ts'),
         'popup/popup': path.join(__dirname, srcDir + 'popup/popup.ts'),
         'utils/cryptoutils': path.join(__dirname, srcDir + 'utils/cryptoutils.ts'),


### PR DESCRIPTION
TODO: We want to include more domains. Most people are accessing weibo
over the .cn TLD.

### Submitter Checklist

- [x] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [x] Tested on Firefox (`npm run firefox`)
- [x] Tested on Chromium (`npm run chromium`)
