### PR TITLE
popup: Clear input on popup close

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -56,6 +56,16 @@ chrome.runtime.onMessage.addListener(
   }
 );
 
+chrome.runtime.onConnect.addListener( ( port: chrome.runtime.Port ) => {
+  console.assert( port.name === 'popup' );
+  port.onDisconnect.addListener( async ( ) => {
+    await sendMessageActiveTab( {
+      request: 'clearInputBox',
+      requestClass: 'injectInput'
+    } );
+  } );
+} );
+
 chrome.commands.onCommand.addListener( async ( command: string ) => {
   if ( command === 'toggle-decryption' ) {
     await sendMessageActiveTab( {

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -147,3 +147,6 @@ window.addEventListener( 'DOMContentLoaded', ( event: Event ) => {
     } );
   }
 } );
+
+// This is a no-op so the background knows when the popup is closed.
+chrome.runtime.connect( { name: 'popup' } );


### PR DESCRIPTION
For the popup, we are not able to catch the `unload` and the
`beforeunload` events. We work around this by setting up a connection
using the Port API and, when the popup closes, the onDisconnect tell the
content script to clear the input box.

### Submitter Checklist

- [x] Tested on Firefox (`npm run firefox`)
- [x] Tested on Chromium (`npm run chromium`)
