### PR TITLE
Add load event listener instead of overriding onload in content script

### DIFF
--- a/src/content/inject.ts
+++ b/src/content/inject.ts
@@ -25,7 +25,7 @@ import { Website } from './website';
 import { Request, Response, sendMessage } from '../utils/message';
 import { load } from './loader';
 
-window.onload = (): void => {
+window.addEventListener( 'load', ( ev: Event ): void => {
   let cryptFrame: HTMLIFrameElement | null;
 
   const activatePicker = (): void => {
@@ -170,4 +170,4 @@ window.onload = (): void => {
       }
     }
   );
-};
+} );


### PR DESCRIPTION
Fixes #64

### Submitter Checklist

- [x] Tested on Firefox (`npm run firefox`)
- [x] Tested on Chromium (`npm run chromium`)
