### PR TITLE
Remove unneeded JS file declarations

### DIFF
--- a/platform/chromium/manifest.json
+++ b/platform/chromium/manifest.json
@@ -20,19 +20,7 @@
         "https://*/*"
       ],
       "js": [
-        "dist/js/content/element-picker.js",
         "dist/js/content/inject.js",
-        "dist/js/content/loader.js",
-        "dist/js/content/walkdom.js",
-        "dist/js/content/website.js",
-        "dist/js/content/websites/discord.js",
-        "dist/js/content/websites/gmail.js",
-        "dist/js/content/websites/mastodon.js",
-        "dist/js/content/websites/slack.js",
-        "dist/js/content/websites/telegram.js",
-        "dist/js/content/websites/weibo.js",
-        "dist/js/utils/message.js",
-        "dist/js/utils/webutils.js",
         "dist/js/vendor.js"
       ],
       "run_at": "document_end"

--- a/platform/firefox/manifest.json
+++ b/platform/firefox/manifest.json
@@ -19,19 +19,7 @@
         "https://*/*"
       ],
       "js": [
-        "dist/js/content/element-picker.js",
         "dist/js/content/inject.js",
-        "dist/js/content/loader.js",
-        "dist/js/content/walkdom.js",
-        "dist/js/content/website.js",
-        "dist/js/content/websites/discord.js",
-        "dist/js/content/websites/gmail.js",
-        "dist/js/content/websites/mastodon.js",
-        "dist/js/content/websites/slack.js",
-        "dist/js/content/websites/telegram.js",
-        "dist/js/content/websites/weibo.js",
-        "dist/js/utils/message.js",
-        "dist/js/utils/webutils.js",
         "dist/js/vendor.js"
       ],
       "run_at": "document_end"

--- a/public/html/popup.html
+++ b/public/html/popup.html
@@ -36,7 +36,6 @@
         <small class="text-muted">Length: <span id="display-length">0</span></small>
       </div>
     </div>
-    <script src="../js/utils/message.js"></script>
     <script src="../js/popup/popup.js"></script>
     <script src="../js/vendor.js"></script>
   </body>

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -6,23 +6,9 @@ const srcDir = '../src/';
 module.exports = {
     entry: {
         'background/background': path.join(__dirname, srcDir + 'background/background.ts'),
-        'content/element-picker': path.join(__dirname, srcDir + 'content/element-picker.ts'),
         'content/inject': path.join(__dirname, srcDir + 'content/inject.ts'),
-        'content/loader': path.join(__dirname, srcDir + 'content/loader.ts'),
-        'content/walkdom': path.join(__dirname, srcDir + 'content/walkdom.ts'),
-        'content/website': path.join(__dirname, srcDir + 'content/website.ts'),
-        'content/websites/discord': path.join(__dirname, srcDir + 'content/websites/discord.ts'),
-        'content/websites/gmail': path.join(__dirname, srcDir + 'content/websites/gmail.ts'),
-        'content/websites/mastodon': path.join(__dirname, srcDir + 'content/websites/mastodon.ts'),
-        'content/websites/slack': path.join(__dirname, srcDir + 'content/websites/slack.ts'),
-        'content/websites/telegram': path.join(__dirname, srcDir + 'content/websites/telegram.ts'),
-        'content/websites/weibo': path.join(__dirname, srcDir + 'content/websites/weibo.ts'),
         'options/options': path.join(__dirname, srcDir + 'options/options.ts'),
         'popup/popup': path.join(__dirname, srcDir + 'popup/popup.ts'),
-        'utils/cryptoutils': path.join(__dirname, srcDir + 'utils/cryptoutils.ts'),
-        'utils/keystore': path.join(__dirname, srcDir + 'utils/keystore.ts'),
-        'utils/message': path.join(__dirname, srcDir + 'utils/message.ts'),
-        'utils/webutils': path.join(__dirname, srcDir + 'utils/webutils.ts'),
         'web_accessible_resources/decrypt': path.join(__dirname, srcDir + 'web_accessible_resources/decrypt.ts'),
     },
     output: {


### PR DESCRIPTION
Since webpack will package all the dependencies of a TS file to the
final JS file, we don't need to compile them or reference them in
manifests and htmls.

Closes #75

### Submitter Checklist

- [x] Tested on Firefox (`npm run firefox`)
- [x] Tested on Chromium (`npm run chromium`)
