### PR TITLE
Add support for The Lounge

### DIFF
--- a/src/content/loader.ts
+++ b/src/content/loader.ts
@@ -27,6 +27,7 @@ import { Slack } from './websites/slack';
 import { Telegram } from './websites/telegram';
 import { Weibo } from './websites/weibo';
 import { WeiboApi } from './websites/weibo-api';
+import { TheLounge } from './websites/thelounge';
 
 export const load = ( location: Location ): Website | null => {
   let siteClasses: Website[] = [];
@@ -36,6 +37,7 @@ export const load = ( location: Location ): Website | null => {
   siteClasses.push( new Mastodon() );
   siteClasses.push( new Slack() );
   siteClasses.push( new Telegram() );
+  siteClasses.push( new TheLounge() );
   siteClasses.push( new Weibo() );
   siteClasses.push( new WeiboApi() );
 

--- a/src/content/websites/thelounge.ts
+++ b/src/content/websites/thelounge.ts
@@ -1,0 +1,56 @@
+/*
+ * This file is part of the Babble project.
+ * Babble is a platform agnostic browser extension that allows for easy
+ * encryption and decryption of text data across the web.
+ * Copyright (C) 2019  keur, yvbbrjdr
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+'use strict';
+
+import { Website } from '../website';
+import { documentObserver } from '../../utils/webutils';
+
+export class TheLounge extends Website {
+  private targetElement: HTMLTextAreaElement | null;
+  constructor () {
+    super();
+    this.domains = [ 'irc.ocf.berkeley.edu', 'demo.thelounge.chat' ];
+    this.targetElement = null;
+  }
+
+  register (): void {
+    documentObserver( ( mutationsList: MutationRecord[], observer: MutationObserver ) => {
+      this.targetElement = document.querySelector( 'textarea.mousetrap' );
+    } );
+  }
+
+  tunnelInput ( s: string ): boolean {
+    if ( !this.targetElement ) {
+      return false;
+    }
+    this.targetElement.value = s;
+    this.targetElement.dispatchEvent( new KeyboardEvent( 'input', { bubbles: true } ) );
+    return true;
+  }
+
+  submitInput (): boolean {
+    if ( !this.targetElement ) {
+      return false;
+    }
+    const submit = document.querySelector("#submit") as HTMLButtonElement;
+    submit.click();
+    return true;
+  }
+}

--- a/src/content/websites/thelounge.ts
+++ b/src/content/websites/thelounge.ts
@@ -49,7 +49,7 @@ export class TheLounge extends Website {
     if ( !this.targetElement ) {
       return false;
     }
-    const submit = document.querySelector("#submit") as HTMLButtonElement;
+    const submit = document.querySelector( '#submit' ) as HTMLButtonElement;
     submit.click();
     return true;
   }

--- a/supported-websites.md
+++ b/supported-websites.md
@@ -5,6 +5,7 @@
 - [Mastodon](https://mastodon.social/)
 - [Slack](https://slack.com/)
 - [Telegram](https://telegram.com/)
+- [The Lounge](https://thelounge.chat/)
 - [Weibo](https://www.weibo.com/)
 
 For unsupported websites, you can copy the encrypted text from the popup to the


### PR DESCRIPTION
### Submitter Checklist

- [x] Tested on Firefox (`npm run firefox`)
- [x] Tested on Chromium (`npm run chromium`)

Notes: The current configuration only has the domains for the OCF IRC and the demo lounge (demo.thelounge.chat). I'm wondering how this can expand to other Lounge instances.